### PR TITLE
Return unmodified version of image if Jetpack is in dev mode.

### DIFF
--- a/wpcom-thumbnail-editor.php
+++ b/wpcom-thumbnail-editor.php
@@ -726,7 +726,7 @@ class WPcom_Thumbnail_Editor {
 
 		list( $selection_x1, $selection_y1, $selection_x2, $selection_y2 ) = $coordinates;
 
-		if( function_exists( 'jetpack_photon_url' ) )
+		if( function_exists( 'jetpack_photon_url' ) &&  !defined('JETPACK_DEV_DEBUG') )
 			$url = jetpack_photon_url(
 				wp_get_attachment_url( $attachment_id ),
 				array(
@@ -743,7 +743,7 @@ class WPcom_Thumbnail_Editor {
 				)
 			);
 		else
-			$url = wp_get_attachment_url( $attachment_id );
+			return $existing_resize;
 
 		return array( $url, $thumbnail_size['width'], $thumbnail_size['height'], true );
 	}


### PR DESCRIPTION
On dev sites, Jetpack is often active but Photon will not work because the content files are not accessible to the public internet. For example, VIP Quickstart dev and staging sites.
Right now, a broken image is displayed when this plugin is active and a thumbnail has been edited. This fix will at least allow the unmodified image to be displayed.
